### PR TITLE
Switch acs_dec_con_ind from required to optional

### DIFF
--- a/proto/three_ds_server_storage.thrift
+++ b/proto/three_ds_server_storage.thrift
@@ -66,7 +66,7 @@ struct ChallengeFlowTransactionInfo {
     1: required ThreeDsServerTransactionID transaction_id
     2: required string                     device_channel
     3: required Timestamp                  decoupled_auth_max_time
-    4: required string                     acs_dec_con_ind
+    4: optional string                     acs_dec_con_ind
     5: required DirectoryServerProviderID  provider_id
     6: required MessageVersion             message_version
     7: required string                     acs_url


### PR DESCRIPTION
Поле не заполняется для `TransactionStatus == "C"` – CHALLENGE_REQUIRED.

<img width="1175" alt="Screen Shot 2021-02-03 at 12 23 01" src="https://user-images.githubusercontent.com/50321018/106725574-95013800-661a-11eb-82dd-f145bc13859b.png">

